### PR TITLE
feat: Log task run errors at ERROR level

### DIFF
--- a/task_processor/processor.py
+++ b/task_processor/processor.py
@@ -99,7 +99,7 @@ def _run_task(task: typing.Union[Task, RecurringTask]) -> typing.Tuple[Task, Tas
         task_run.finished_at = timezone.now()
         task.mark_success()
     except Exception as e:
-        logger.warning(
+        logger.error(
             "Failed to execute task '%s'. Exception was: %s",
             task.task_identifier,
             str(e),

--- a/tests/unit/task_processor/test_unit_task_processor_processor.py
+++ b/tests/unit/task_processor/test_unit_task_processor_processor.py
@@ -240,9 +240,9 @@ def test_run_task_runs_task_and_creates_task_run_object_when_failure(
 
     assert len(caplog.records) == 3
 
-    warning_log = caplog.records[0]
-    assert warning_log.levelname == "WARNING"
-    assert warning_log.message == (
+    log_record = caplog.records[0]
+    assert log_record.levelname == "ERROR"
+    assert log_record.message == (
         f"Failed to execute task '{task.task_identifier}'. Exception was: {msg}"
     )
 


### PR DESCRIPTION
This should allow us to see task processing errors in Sentry.