### PR TITLE
feat: Add basic debug logging, remove "no tasks to process" spam from debug logs

### DIFF
--- a/task_processor/processor.py
+++ b/task_processor/processor.py
@@ -45,6 +45,7 @@ def run_tasks(num_tasks: int = 1) -> typing.List[TaskRun]:
 
         if task_runs:
             TaskRun.objects.bulk_create(task_runs)
+            logger.debug(f"Finished running {len(task_runs)} tasks")
 
         return task_runs
 
@@ -57,6 +58,8 @@ def run_recurring_tasks() -> typing.List[RecurringTaskRun]:
     # a problem for now, but we should be mindful of this limitation
     tasks = RecurringTask.objects.get_tasks_to_process()
     if tasks:
+        logger.debug(f"Running {len(tasks)} recurring tasks")
+
         task_runs = []
 
         for task in tasks:
@@ -81,8 +84,8 @@ def run_recurring_tasks() -> typing.List[RecurringTaskRun]:
         RecurringTask.objects.bulk_update(to_update, fields=["is_locked", "locked_at"])
 
         if task_runs:
-            logger.debug(f"Running {len(task_runs)} recurring tasks")
             RecurringTaskRun.objects.bulk_create(task_runs)
+            logger.debug(f"Finished running {len(task_runs)} recurring tasks")
 
         return task_runs
 

--- a/task_processor/processor.py
+++ b/task_processor/processor.py
@@ -48,7 +48,6 @@ def run_tasks(num_tasks: int = 1) -> typing.List[TaskRun]:
 
         return task_runs
 
-    logger.trace("No tasks to process.")
     return []
 
 
@@ -87,7 +86,6 @@ def run_recurring_tasks() -> typing.List[RecurringTaskRun]:
 
         return task_runs
 
-    logger.trace("No recurring tasks to process.")
     return []
 
 

--- a/task_processor/processor.py
+++ b/task_processor/processor.py
@@ -92,7 +92,9 @@ def run_recurring_tasks() -> typing.List[RecurringTaskRun]:
 
 
 def _run_task(task: typing.Union[Task, RecurringTask]) -> typing.Tuple[Task, TaskRun]:
-    logger.debug(f"Running task {task.task_identifier} id={task.id} args={task.args} kwargs={task.kwargs}")
+    logger.debug(
+        f"Running task {task.task_identifier} id={task.id} args={task.args} kwargs={task.kwargs}"
+    )
     task_run = task.task_runs.model(started_at=timezone.now(), task=task)
 
     try:

--- a/task_processor/processor.py
+++ b/task_processor/processor.py
@@ -26,7 +26,7 @@ def run_tasks(num_tasks: int = 1) -> typing.List[TaskRun]:
     tasks = Task.objects.get_tasks_to_process(num_tasks)
 
     if tasks:
-        logger.debug(f"Running {len(tasks)} tasks")
+        logger.debug(f"Running {len(tasks)} task(s)")
 
         executed_tasks = []
         task_runs = []
@@ -45,7 +45,7 @@ def run_tasks(num_tasks: int = 1) -> typing.List[TaskRun]:
 
         if task_runs:
             TaskRun.objects.bulk_create(task_runs)
-            logger.debug(f"Finished running {len(task_runs)} tasks")
+            logger.debug(f"Finished running {len(task_runs)} task(s)")
 
         return task_runs
 
@@ -58,7 +58,7 @@ def run_recurring_tasks() -> typing.List[RecurringTaskRun]:
     # a problem for now, but we should be mindful of this limitation
     tasks = RecurringTask.objects.get_tasks_to_process()
     if tasks:
-        logger.debug(f"Running {len(tasks)} recurring tasks")
+        logger.debug(f"Running {len(tasks)} recurring task(s)")
 
         task_runs = []
 
@@ -85,7 +85,7 @@ def run_recurring_tasks() -> typing.List[RecurringTaskRun]:
 
         if task_runs:
             RecurringTaskRun.objects.bulk_create(task_runs)
-            logger.debug(f"Finished running {len(task_runs)} recurring tasks")
+            logger.debug(f"Finished running {len(task_runs)} recurring task(s)")
 
         return task_runs
 
@@ -121,8 +121,6 @@ def _run_task(task: typing.Union[Task, RecurringTask]) -> typing.Tuple[Task, Tas
             err_msg,
             exc_info=True,
         )
-        logger.debug("args: %s", str(task.args))
-        logger.debug("kwargs: %s", str(task.kwargs))
 
         task.mark_failure()
 

--- a/tests/unit/task_processor/test_unit_task_processor_processor.py
+++ b/tests/unit/task_processor/test_unit_task_processor_processor.py
@@ -361,9 +361,15 @@ def test_run_task_runs_task_and_creates_task_run_object_when_failure(
 
     expected_log_records = [
         ("DEBUG", "Running 1 task(s)"),
-        ("DEBUG", f"Running task {task.task_identifier} id={task.id} args={task.args} kwargs={task.kwargs}"),
-        ("ERROR", f"Failed to execute task '{task.task_identifier}', with id {task.id}. Exception: {msg}"),
-        ("DEBUG", "Finished running 1 task(s)")
+        (
+            "DEBUG",
+            f"Running task {task.task_identifier} id={task.id} args={task.args} kwargs={task.kwargs}",
+        ),
+        (
+            "ERROR",
+            f"Failed to execute task '{task.task_identifier}', with id {task.id}. Exception: {msg}",
+        ),
+        ("DEBUG", "Finished running 1 task(s)"),
     ]
 
     assert expected_log_records == [

--- a/tests/unit/task_processor/test_unit_task_processor_processor.py
+++ b/tests/unit/task_processor/test_unit_task_processor_processor.py
@@ -359,20 +359,16 @@ def test_run_task_runs_task_and_creates_task_run_object_when_failure(
     task.refresh_from_db()
     assert not task.completed
 
-    assert len(caplog.records) == 5
+    expected_log_records = [
+        ("DEBUG", "Running 1 task(s)"),
+        ("DEBUG", f"Running task {task.task_identifier} id={task.id} args={task.args} kwargs={task.kwargs}"),
+        ("ERROR", f"Failed to execute task '{task.task_identifier}', with id {task.id}. Exception: {msg}"),
+        ("DEBUG", "Finished running 1 task(s)")
+    ]
 
-    log_record = caplog.records[0]
-    assert log_record.levelname == "ERROR"
-    assert log_record.message == (
-        f"Failed to execute task '{task.task_identifier}', with id {task.id}. Exception: {msg}"
-    )
-
-    debug_log_args, debug_log_kwargs = caplog.records[1:]
-    assert debug_log_args.levelname == "DEBUG"
-    assert debug_log_args.message == f"args: ['{msg}']"
-
-    assert debug_log_kwargs.levelname == "DEBUG"
-    assert debug_log_kwargs.message == "kwargs: {}"
+    assert expected_log_records == [
+        (record.levelname, record.message) for record in caplog.records
+    ]
 
 
 def test_run_task_runs_failed_task_again(db):

--- a/tests/unit/task_processor/test_unit_task_processor_processor.py
+++ b/tests/unit/task_processor/test_unit_task_processor_processor.py
@@ -359,7 +359,7 @@ def test_run_task_runs_task_and_creates_task_run_object_when_failure(
     task.refresh_from_db()
     assert not task.completed
 
-    assert len(caplog.records) == 3
+    assert len(caplog.records) == 5
 
     log_record = caplog.records[0]
     assert log_record.levelname == "ERROR"


### PR DESCRIPTION
Add debug logs for:

* Starting to execute a task batch
* Executing an individual task within a batch
* Completing a task successfully

Remove debug logs for when there are no tasks to execute, as this quickly fills the debug log output with useless information.

This is completely untested.