### PR TITLE
fix(monitoring): exclude locked and future scheduled tasks from monitoring

### DIFF
--- a/task_processor/monitoring.py
+++ b/task_processor/monitoring.py
@@ -1,0 +1,12 @@
+from django.utils import timezone
+
+from task_processor.models import Task
+
+
+def get_num_waiting_tasks() -> int:
+    return Task.objects.filter(
+        num_failures__lt=3,
+        completed=False,
+        scheduled_for__lt=timezone.now(),
+        is_locked=False,
+    ).count()

--- a/task_processor/views.py
+++ b/task_processor/views.py
@@ -3,7 +3,7 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
-from task_processor.models import Task
+from task_processor.monitoring import get_num_waiting_tasks
 from task_processor.serializers import MonitoringSerializer
 
 
@@ -11,7 +11,7 @@ from task_processor.serializers import MonitoringSerializer
 @api_view(http_method_names=["GET"])
 @permission_classes([IsAuthenticated, IsAdminUser])
 def monitoring(request, **kwargs):
-    waiting_tasks = Task.objects.filter(num_failures__lt=3, completed=False).count()
     return Response(
-        data={"waiting": waiting_tasks}, headers={"Content-Type": "application/json"}
+        data={"waiting": get_num_waiting_tasks()},
+        headers={"Content-Type": "application/json"},
     )

--- a/tests/unit/task_processor/test_unit_task_processor_monitoring.py
+++ b/tests/unit/task_processor/test_unit_task_processor_monitoring.py
@@ -1,0 +1,38 @@
+from datetime import timedelta
+
+from django.utils import timezone
+
+from task_processor.models import Task
+from task_processor.monitoring import get_num_waiting_tasks
+
+
+def test_get_num_waiting_tasks(db: None) -> None:
+    # Given
+    now = timezone.now()
+
+    # a task that is waiting
+    Task.objects.create(task_identifier="tasks.test_task")
+
+    # a task that is scheduled for the future
+    Task.objects.create(
+        task_identifier="tasks.test_task", scheduled_for=now + timedelta(days=1)
+    )
+
+    # and a task that has been completed
+    Task.objects.create(
+        task_identifier="tasks.test_task",
+        scheduled_for=now - timedelta(days=1),
+        completed=True,
+    )
+
+    # and a task that has been locked for processing
+    Task.objects.create(
+        task_identifier="tasks.test_task",
+        is_locked=True,
+    )
+
+    # When
+    num_waiting_tasks = get_num_waiting_tasks()
+
+    # Then
+    assert num_waiting_tasks == 1


### PR DESCRIPTION
Updates the monitoring endpoint to exclude locked tasks, and those scheduled for the future from the monitoring endpoint data. 