### PR TITLE
fix(recurring-task): reduce update load on `task_processor_recurringtask` table 

### DIFF
--- a/task_processor/management/commands/runprocessor.py
+++ b/task_processor/management/commands/runprocessor.py
@@ -7,8 +7,7 @@ from datetime import timedelta
 from django.core.management import BaseCommand
 from django.utils import timezone
 
-from task_processor.models import RecurringTask
-from task_processor.task_registry import TaskType, registered_tasks
+from task_processor.task_registry import initialise
 from task_processor.thread_monitoring import (
     clear_unhealthy_threads,
     write_unhealthy_threads,
@@ -75,18 +74,9 @@ class Command(BaseCommand):
             ]
         )
 
-        logger.info(
-            "Processor starting. Registered tasks are: %s",
-            list(registered_tasks.keys()),
-        )
+        logger.info("Processor starting")
 
-        # Update the recurring tasks in the database if needed based on registry
-        for task_identifier, task in registered_tasks.items():
-            if task.task_type == TaskType.RECURRING:
-                RecurringTask.objects.update_or_create(
-                    task_identifier=task_identifier,
-                    defaults=task.task_kwargs,
-                )
+        initialise()
 
         for thread in self._threads:
             thread.start()

--- a/task_processor/models.py
+++ b/task_processor/models.py
@@ -68,7 +68,8 @@ class AbstractBaseTask(models.Model):
     @property
     def callable(self) -> typing.Callable:
         try:
-            return registered_tasks[self.task_identifier]
+            task = registered_tasks[self.task_identifier]
+            return task.task_function
         except KeyError as e:
             raise TaskProcessingError(
                 "No task registered with identifier '%s'. Ensure your task is "

--- a/task_processor/task_registry.py
+++ b/task_processor/task_registry.py
@@ -47,18 +47,11 @@ def get_task(task_identifier: str) -> RegisteredTask:
 def register_task(task_identifier: str, callable_: typing.Callable) -> None:
     global registered_tasks
 
-    logger.debug("Registering task '%s'", task_identifier)
-
     registered_task = RegisteredTask(
         task_identifier=task_identifier,
         task_function=callable_,
     )
     registered_tasks[task_identifier] = registered_task
-
-    logger.debug(
-        "Registered tasks now has the following tasks registered: %s",
-        list(registered_tasks.keys()),
-    )
 
 
 def register_recurring_task(

--- a/task_processor/task_registry.py
+++ b/task_processor/task_registry.py
@@ -22,6 +22,28 @@ class RegisteredTask:
 registered_tasks: typing.Dict[str, RegisteredTask] = {}
 
 
+def initialise() -> None:
+    global registered_tasks
+
+    from task_processor.models import RecurringTask
+
+    for task_identifier, registered_task in registered_tasks.items():
+        logger.debug("Initialising task '%s'", task_identifier)
+
+        if registered_task.task_type == TaskType.RECURRING:
+            logger.debug("Persisting recurring task '%s'", task_identifier)
+            RecurringTask.objects.update_or_create(
+                task_identifier=task_identifier,
+                defaults=registered_task.task_kwargs,
+            )
+
+
+def get_task(task_identifier: str) -> RegisteredTask:
+    global registered_tasks
+
+    return registered_tasks[task_identifier]
+
+
 def register_task(task_identifier: str, callable_: typing.Callable) -> None:
     global registered_tasks
 

--- a/task_processor/task_registry.py
+++ b/task_processor/task_registry.py
@@ -1,17 +1,37 @@
+import enum
 import logging
 import typing
+from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 
-registered_tasks: typing.Dict[str, typing.Callable] = {}
+
+class TaskType(enum.Enum):
+    STANDARD = "STANDARD"
+    RECURRING = "RECURRING"
 
 
-def register_task(task_identifier: str, callable_: typing.Callable):
+@dataclass
+class RegisteredTask:
+    task_identifier: str
+    task_function: typing.Callable
+    task_type: TaskType = TaskType.STANDARD
+    task_kwargs: typing.Dict[str, typing.Any] = None
+
+
+registered_tasks: typing.Dict[str, RegisteredTask] = {}
+
+
+def register_task(task_identifier: str, callable_: typing.Callable) -> None:
     global registered_tasks
 
     logger.debug("Registering task '%s'", task_identifier)
 
-    registered_tasks[task_identifier] = callable_
+    registered_task = RegisteredTask(
+        task_identifier=task_identifier,
+        task_function=callable_,
+    )
+    registered_tasks[task_identifier] = registered_task
 
     logger.debug(
         "Registered tasks now has the following tasks registered: %s",
@@ -19,5 +39,22 @@ def register_task(task_identifier: str, callable_: typing.Callable):
     )
 
 
-def get_task(task_identifier: str) -> typing.Callable:
-    return registered_tasks[task_identifier]
+def register_recurring_task(
+    task_identifier: str, callable_: typing.Callable, **task_kwargs
+) -> None:
+    global registered_tasks
+
+    logger.debug("Registering recurring task '%s'", task_identifier)
+
+    registered_task = RegisteredTask(
+        task_identifier=task_identifier,
+        task_function=callable_,
+        task_type=TaskType.RECURRING,
+        task_kwargs=task_kwargs,
+    )
+    registered_tasks[task_identifier] = registered_task
+
+    logger.debug(
+        "Registered tasks now has the following tasks registered: %s",
+        list(registered_tasks.keys()),
+    )

--- a/tests/unit/task_processor/conftest.py
+++ b/tests/unit/task_processor/conftest.py
@@ -3,6 +3,8 @@ import typing
 
 import pytest
 
+from task_processor.task_registry import RegisteredTask
+
 
 @pytest.fixture
 def run_by_processor(monkeypatch):
@@ -33,3 +35,11 @@ def get_task_processor_caplog(
         return caplog
 
     return _inner
+
+
+@pytest.fixture(autouse=True)
+def task_registry() -> typing.Generator[dict[str, RegisteredTask], None, None]:
+    from task_processor.task_registry import registered_tasks
+
+    registered_tasks.clear()
+    yield registered_tasks

--- a/tests/unit/task_processor/test_unit_task_processor_decorators.py
+++ b/tests/unit/task_processor/test_unit_task_processor_decorators.py
@@ -14,7 +14,7 @@ from task_processor.decorators import (
 )
 from task_processor.exceptions import InvalidArgumentsError
 from task_processor.models import RecurringTask, Task, TaskPriority
-from task_processor.task_registry import get_task
+from task_processor.task_registry import get_task, initialise
 from task_processor.task_run_method import TaskRunMethod
 
 if typing.TYPE_CHECKING:
@@ -113,6 +113,8 @@ def test_register_recurring_task(mocker, db, run_by_processor):
         return first_arg + second_arg
 
     # Then
+    initialise()
+
     task = RecurringTask.objects.get(task_identifier=task_identifier)
     assert task.serialized_kwargs == json.dumps(task_kwargs)
     assert task.run_every == run_every

--- a/tests/unit/task_processor/test_unit_task_processor_models.py
+++ b/tests/unit/task_processor/test_unit_task_processor_models.py
@@ -6,22 +6,24 @@ from django.utils import timezone
 
 from task_processor.decorators import register_task_handler
 from task_processor.models import RecurringTask, Task
+from task_processor.task_registry import initialise
 
 now = timezone.now()
 one_hour_ago = now - timedelta(hours=1)
 one_hour_from_now = now + timedelta(hours=1)
 
 
-@register_task_handler()
-def my_callable(arg_one: str, arg_two: str = None):
-    """Example callable to use for tasks (needs to be global for registering to work)"""
-    return arg_one, arg_two
-
-
 def test_task_run():
     # Given
+    @register_task_handler()
+    def my_callable(arg_one: str, arg_two: str = None):
+        """Example callable to use for tasks (needs to be global for registering to work)"""
+        return arg_one, arg_two
+
     args = ["foo"]
     kwargs = {"arg_two": "bar"}
+
+    initialise()
 
     task = Task.create(
         my_callable.task_identifier,


### PR DESCRIPTION
This is a WIP / PoC for a hypothesis that we are seeing a high number of updates on the `task_processor_recurringtask` table due to the fact that an `update_or_create` is called every time that a module is reloaded that includes a function decorated with `@register_recurring_task()`. 

The general approach is to only update the recurring tasks when the processor starts instead. There's a chance that we could optimise this further and only do it on a deployment, but this should at least reduce the load significantly in environments that are running a lot of instances of the Flagsmith application which may also be getting terminated / instantiated regularly. 